### PR TITLE
feat: Add configuration mode selector to extract operation

### DIFF
--- a/nodes/LlamaParsePlatform/LlamaParsePlatform.node.ts
+++ b/nodes/LlamaParsePlatform/LlamaParsePlatform.node.ts
@@ -339,18 +339,27 @@ export class LlamaParsePlatform implements INodeType {
 						const baseUrl =
 							(credentials.baseURL as string | null) ?? 'https://api.cloud.llamaindex.ai';
 
-						let ds = this.getNodeParameter('dataSchema', i) as unknown;
-						if (typeof ds === 'string') {
-							ds = JSON.parse(ds);
-						} else if (typeof ds !== 'object') {
-							// Not an HTTP-related exception, hence not a NodeApiError
-							throw new NodeOperationError(
-								this.getNode(),
-								`Invalid input type for data schema: ${typeof ds}`,
-								{ itemIndex: i },
-							);
-						}
+						const configMode = this.getNodeParameter('configMode', i) as 'schema' | 'configId';
 						const http = { apiKey, baseUrl };
+
+						let extractJobBody: Record<string, unknown>;
+						if (configMode === 'schema') {
+							let ds = this.getNodeParameter('dataSchema', i) as unknown;
+							if (typeof ds === 'string') {
+								ds = JSON.parse(ds);
+							} else if (typeof ds !== 'object') {
+								// Not an HTTP-related exception, hence not a NodeApiError
+								throw new NodeOperationError(
+									this.getNode(),
+									`Invalid input type for data schema: ${typeof ds}`,
+									{ itemIndex: i },
+								);
+							}
+							extractJobBody = { configuration: { data_schema: ds } };
+						} else {
+							const configId = this.getNodeParameter('configId', i) as string;
+							extractJobBody = { configuration_id: configId };
+						}
 
 						let fileId: string;
 						try {
@@ -373,9 +382,7 @@ export class LlamaParsePlatform implements INodeType {
 						try {
 							const job = await postJSON<{ id: string }>(http, '/api/v2/extract', {
 								file_input: fileId,
-								configuration: {
-									data_schema: ds,
-								},
+								...extractJobBody,
 							});
 							jobId = job.id;
 						} catch (e) {

--- a/nodes/LlamaParsePlatform/resources/extract/index.ts
+++ b/nodes/LlamaParsePlatform/resources/extract/index.ts
@@ -23,6 +23,31 @@ export const extractProperties: INodeProperties[] = [
 		noDataExpression: true,
 	},
 	{
+		displayName: 'Configuration Mode',
+		name: 'configMode',
+		type: 'options',
+		options: [
+			{
+				name: 'Schema',
+				value: 'schema',
+				description: 'Provide an inline JSON schema defining the extraction structure',
+			},
+			{
+				name: 'Configuration ID',
+				value: 'configId',
+				description: 'Use a saved LlamaExtract configuration from the LlamaCloud dashboard',
+			},
+		],
+		default: 'schema',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				operation: ['extract'],
+				resource: ['extracting'],
+			},
+		},
+	},
+	{
 		displayName: 'Data Schema',
 		name: 'dataSchema',
 		type: 'json',
@@ -31,11 +56,29 @@ export const extractProperties: INodeProperties[] = [
 			show: {
 				operation: ['extract'],
 				resource: ['extracting'],
+				configMode: ['schema'],
 			},
 		},
 		default: '',
 		placeholder: '',
 		description: 'JSON schema representing the structure the extracted data should follow',
+	},
+	{
+		displayName: 'Configuration ID',
+		name: 'configId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: ['extract'],
+				resource: ['extracting'],
+				configMode: ['configId'],
+			},
+		},
+		default: '',
+		placeholder: 'e.g. 1234abcd-...',
+		description:
+			'ID of the LlamaExtract configuration that defines the schema and prompts. Create one in the LlamaCloud dashboard under Extract.',
 	},
 	{
 		displayName: 'Binary Property',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@llamaindex/n8n-nodes-llamacloud",
-	"version": "6.5.0",
+	"version": "6.5.1",
 	"description": "LlamaParse Platform integration with n8n",
 	"license": "MIT",
 	"homepage": "https://run-llama.github.io/n8n-llamacloud/",


### PR DESCRIPTION
## Summary

- Adds a **Configuration Mode** selector to the Extract operation with two options:
  - **Schema** (default) — provide an inline JSON schema (current behaviour, unchanged)
  - **Configuration ID** — enter a saved LlamaExtract configuration ID from the LlamaCloud dashboard (restores the pre-#35 approach)
- The `dataSchema` field is now conditionally shown only in Schema mode
- The `configId` string field (restored from before PR #35) is shown only in Configuration ID mode
- Execute logic branches on `configMode`: sends `configuration: { data_schema }` or `configuration_id` accordingly


