### PR TITLE
feat: add search aliases for improved node discoverability

### DIFF
--- a/nodes/LlamaParsePlatform/LlamaParse.node.json
+++ b/nodes/LlamaParsePlatform/LlamaParse.node.json
@@ -14,5 +14,20 @@
 				"url": "https://developers.llamaindex.ai/llamaparse/general/api_key/"
 			}
 		]
-	}
+	},
+	"alias": [
+		"pdf",
+		"extract",
+		"ocr",
+		"invoice",
+		"scan",
+		"parse",
+		"parser",
+		"parsing",
+		"document",
+		"document parsing",
+		"llamaparse",
+		"llama parse",
+		"text extraction"
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@llamaindex/n8n-nodes-llamacloud",
-	"version": "6.5.2",
+	"version": "6.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@llamaindex/n8n-nodes-llamacloud",
-			"version": "6.5.2",
+			"version": "6.7.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@changesets/cli": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@llamaindex/n8n-nodes-llamacloud",
-	"version": "6.7.0",
+	"version": "6.7.1",
 	"description": "LlamaParse Platform integration with n8n",
 	"license": "MIT",
 	"homepage": "https://run-llama.github.io/n8n-llamacloud/",


### PR DESCRIPTION
Adds a `codex.alias` list (pdf, extract, ocr, invoice, scan, parse, parser, document, …) so the node surfaces for common document-parsing search terms in the n8n nodes/tools search panel.

Made with [Cursor](https://cursor.com)